### PR TITLE
drivers/str/sad.c: correctly check for UID 0 on kernel 3.10+

### DIFF
--- a/drivers/str/sad.c
+++ b/drivers/str/sad.c
@@ -313,7 +313,7 @@ nak_it:		mp->b_datap->db_type = M_IOCNAK;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
 		if (iocp->ioc_uid != 0) {
 #else
-                if (uid_valid(iocp->ioc_uid)) {
+                if (__kuid_val(iocp->ioc_uid) != 0) {
 #endif
 			err = -EACCES;
 			goto nak_it;


### PR DESCRIPTION
The CSLiS patch to drivers/str/sad.c to work on kernel 3.10+ (in which UIDs and GIDs are no longer plain integers) changed a check for UID 0 to a call to uid_valid(). This is not correct, because uid_valid() checks for *any* valid UID (only -1 is considered invalid). Correct the check to use __kuid_val() to check the UID value against 0.

This is technically a security vulnerability, because it allows any user to access the sad driver rather than only root, but the attack surface is so tiny (it only allows configuring STREAMS module autopushing) that I don't think it's worth handling it as one.